### PR TITLE
Origin-center grids by default; fix a type conversion; update tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,9 @@ uuid = "a1b4810d-1bce-5fbd-ac56-80944d57a21f"
 julia = "0.7, 1"
 
 [extras]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Random", "Statistics"]

--- a/src/Hexagons.jl
+++ b/src/Hexagons.jl
@@ -62,7 +62,7 @@ function convert(::Type{HexagonAxial}, hex::HexagonOffsetEvenR)
 end
 
 function convert(::Type{HexagonCubic}, hex::HexagonAxial)
-    HexagonCubic(hex.q, hex.r, -hex.q - hex.r)
+    HexagonCubic(hex.q, -hex.q - hex.r, hex.r)
 end
 
 function convert(::Type{HexagonCubic}, hex::HexagonOffsetOddR)
@@ -329,7 +329,7 @@ function distance(a::Hexagon, b::Hexagon)
         abs(hexa.z - hexb.z))
 end
 
-function center(hex::Hexagon, xsize=1.0, ysize=1.0, xoff=1.0, yoff=1.0)
+function center(hex::Hexagon, xsize=1.0, ysize=1.0, xoff=0.0, yoff=0.0)
     axh = convert(HexagonAxial, hex)
     (xoff + xsize * sqrt(3) * (axh.q + axh.r/2), yoff + ysize * (3/2) * axh.r)
 end
@@ -375,21 +375,7 @@ function cube_round(x, y, xsize=1.0, ysize=1.0)
     q = sqrt(3)/3 * x - y/3
     r = 2 * y / 3
     h = nearest_cubic_hexagon(q, -q - r, r)
-    #return h
-
-    x0, y0 = center(h)
-    d0 = (x0-x)^2 + (y0-y)^2
-    h_best = h
-    d_best = d0
-    for neighbor in neighbors(h)
-        xn, yn = center(neighbor)
-        dn = (xn-x)^2 + (yn-y)^2
-        if dn < d_best
-            d_best = dn
-            h_best = neighbor
-        end
-    end
-    h_best
+    return h
 end
 
 end # module Hexagons

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,42 @@
 using Hexagons
 using Test
+using Random: seed!
+using Statistics: mean
 
-convert(HexagonOffsetOddR, HexagonAxial(2, 4))
-
-x, y = center(HexagonAxial(2, 3))
-@test isapprox(x,7.06217782649107)
-@test isapprox(y,5.5)
-
-h = cube_round(23.5, 4.67)
-
-collect(vertices(HexagonAxial(2, 3)))
+# Test a few identities for the hexagon containing the point x, y
+function run_point_test(x, y)
+    hex_cubic = cube_round(x, y)
+    verts = collect(vertices(hex_cubic))
+    # x,y should be in the bounding box of the hexagon vertices
+    @test minimum(v[1] for v in verts) <= x <= maximum(v[1] for v in verts)
+    @test minimum(v[2] for v in verts) <= y <= maximum(v[2] for v in verts)
+    # the center of the hexagon should be near its vertex mean
+    mean_vert_x = mean(v[1] for v in verts)
+    mean_vert_y = mean(v[2] for v in verts)
+    hex_center = center(hex_cubic)
+    @test isapprox(hex_center[1], mean_vert_x; atol = 1e-6)
+    @test isapprox(hex_center[2], mean_vert_y; atol = 1e-6)
+    # a string of type conversions should recover hex_cubic
+    hex_axial = convert(HexagonAxial, hex_cubic)
+    hex_offset = convert(HexagonOffsetOddR, hex_axial)
+    other_hex_cubic = convert(HexagonCubic, hex_offset)
+    @test other_hex_cubic == hex_cubic
+end
+    
+test_points = [
+    (0, 0),
+    (1, 1),
+    (1, -1),
+    (0, 47),
+    (-4.7, 0),
+    (1.234, 5.678),
+    (1e6, 2e6),
+]
+# bunch of random test points
+seed!(1234)
+for _ in 1:1000
+    push!(test_points, (rand() * 100, rand() * 100))
+end
+for point in test_points
+    run_point_test(point...)
+end


### PR DESCRIPTION
* Update the tests to ensure some basic behavior. The test coverage is still quite minimal, but nonetheless expanded relative to master. And I think all the behavior tested for should be uncontroversial.
* Set the default `x` and `y` offset for `center` to be 0, not 1. This means that the zero index hexagon (e.g. `HexagonCubic(0, 0, 0)`) will be centered at the xy origin. This should fix both https://github.com/GiovineItalia/Hexagons.jl/issues/13 and https://github.com/GiovineItalia/Gadfly.jl/issues/1497 .
* Fix axial to cubic conversion. The current master has
```
function convert(::Type{HexagonCubic}, hex::HexagonAxial)
    HexagonCubic(hex.q, hex.r, -hex.q - hex.r)
end
```
compare to Amit Patel's [reference](https://www.redblobgames.com/grids/hexagons/):
```
function axial_to_cube(hex):
    var x = hex.q
    var z = hex.r
    var y = -x-z
    return Cube(x, y, z)
```
i.e. the `-q-r` term should become the cubic `y` (second argument), but current master puts this term in cubic `z`.